### PR TITLE
Update REUSE.toml

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,5 +6,5 @@ SPDX-PackageDownloadLocation = "https://github.com/PrivateCorner/esp32-hdmi-swit
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 The PrivateCorner Authors"
+SPDX-FileCopyrightText = "2024 The PrivateCorner Authors"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Rolling back the year to test a renovate datasource which shall keep this value up to date.